### PR TITLE
Add specification value with html

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add attribute dangerouslySetInnerHTML on specificationValue
+
 ## [1.0.1] - 2020-09-02
 
 ### Fixed

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,7 +30,7 @@ Now, you can use all the blocks exported by the `product-specifications` app. Ch
 | ----------------------------- | --------------------------------------------------------------------------------------------------------------- |
 | `product-specification-group` | Renders the product specification group.                                                     |
 | `product-specification`       | Renders the product specification. It should be declared as a children of `product-specification-group`. |
-| `product-specification-value` | Renders the product specification value. It should be declared as a children of `product-specification`.  |
+| `product-specification-value` | Renders the product specification value. It should be declared as a children of `product-specification`. It is possible to render with `HTML`. |
 | `product-specification-text`  | Mandatory children of `product-specification-group`, `product-specification` and `product-specification-value`. Depending on which block it is declared, the `product-specification-text` renders data regarding a specification group, a specification, or a specification value. |
 
 ### Step 2 - Adding the Product Specifications' blocks to your theme's templates

--- a/react/ProductSpecificationText.tsx
+++ b/react/ProductSpecificationText.tsx
@@ -86,9 +86,8 @@ const ProductSpecificationText: FC<Props> = ({
           value.isFirst ? 'first' : '',
           value.isLast ? 'last' : '',
         ])}
-      >
-        {value.value}
-      </span>
+        dangerouslySetInnerHTML={{ __html: value.value }}
+      />
     )
     result.isFirstSpecificationValue = value.isFirst
     result.isLastSpecificationValue = value.isLast


### PR DESCRIPTION
What is the purpose of this pull request?

The purpose of this PR is to allow the rendering of HTML code in the value of the product specification. The project is a migration of the  CMS [store](https://www.lebiscuit.com.br/linha-clea-1000m-n82-8990-preto-5047047035/p) to VTEX IO,   the control  used  it was ` <vtex.cmc:productSpecification/>`. This is the [link](https://help.vtex.com/en/tutorial/lista-de-controles-para-templates--tutorials_563) that allows the use of HTML. However in VTEX IO it is not possible.

What problem is this solving?

Unable to process HTML code in the product specification value

How should this be tested manually?

Here is a workspace for further testing https://specificationpr--iolebiscuit.myvtex.com/linha-clea-1000m-n82-8990-preto-5047047035/p

And here the impressions showing these changes Workspace corrected: https://prnt.sc/10o70x6 - Master with error: https://prnt.sc/10o68rr

Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.


Fixes https://github.com/vtex-apps/store-discussion/issues/568