### PR TITLE
Feature/add filter specifications

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -152,6 +152,19 @@ You can also use other blocks to wrap the blocks provided by the Product Specifi
 | `specificationGroups` | `[string]` | Array of specification group names to be hidden or shown (depending on what is defined in the `type` property) by the `product-specification-group` block. | `undefined`   |
 | `type` | `enum` | Determines whether the specification group names passed to the `specificationGroups` prop should be displayed or hidden on the UI. Possible values are: `hide` (hides specification groups declared in the `specificationGroups` prop) or `show` (only shows the specification groups declared in the `specificationGroups` prop). | `undefined` |
 
+### `product-specification` props
+
+| Prop name | Type     | Description                                               | Default value |
+| --------- | -------- | --------------------------------------------------------- | ------------- |
+| `filter`  | `object` | Filters the specifications that the block should display. | `undefined`   |
+
+- **`filter` object:**
+
+| Prop name | Type | Description | Default value |
+| - | - | - | - |
+| `specifications` | `[string]` | Array of specifications names to be hidden or shown (depending on what is defined in the `type` property) by the `product-specification` block. | `undefined`   |
+| `type` | `enum` | Determines whether the specification names passed to the `specifications` prop should be displayed or hidden on the UI. Possible values are: `hide` (hides specifications declared in the `specificationGs` prop) or `show` (only shows the specifications declared in the `specifications` prop). | `undefined` |
+
 #### `product-specification-text` props
 
 | Prop name | Type | Description | Default value |

--- a/react/ProductSpecification.tsx
+++ b/react/ProductSpecification.tsx
@@ -1,10 +1,40 @@
-import React, { FC, useContext } from 'react'
+import React, { FC, useContext, ReactNode, useMemo } from 'react'
 import { Specification } from 'vtex.product-context'
 
 import { useProductSpecificationGroup } from './ProductSpecificationGroup'
 
-const ProductSpecificationGroup: FC = ({ children }) => {
+interface ProductSpecificationProps {
+  filter?: {
+    type: 'hide' | 'show'
+    specifications: string[]
+  }
+  children: ReactNode
+}
+
+const defaultFilter: ProductSpecificationProps['filter'] = {
+  type: 'hide',
+  specifications: [],
+}
+
+const ProductSpecificationGroup: FC<ProductSpecificationProps> = ({
+  filter = defaultFilter,
+  children }) => {
   const group = useProductSpecificationGroup()
+  const specificationsGroup = group?.specifications
+  const { type, specifications: filterSpecificationGroups } = filter
+
+  const specification = useMemo(
+    () =>
+      specificationsGroup?.filter((specification) => {
+        const hasSpecification = filterSpecificationGroups.includes(specification.originalName)
+        if ((type === 'hide' && hasSpecification) || (type === 'show' && !hasSpecification)) {
+          return false
+        }
+
+        return true
+      }),
+    [specificationsGroup, type, filterSpecificationGroups]
+  )
 
   if (!group) {
     return null
@@ -12,7 +42,7 @@ const ProductSpecificationGroup: FC = ({ children }) => {
 
   return (
     <>
-      {group.specifications.map((specification, index) => (
+      {specification?.map((specification, index) => (
         <ProductSpecificationProvider key={index} specification={specification}>
           {children}
         </ProductSpecificationProvider>

--- a/react/package.json
+++ b/react/package.json
@@ -20,7 +20,7 @@
     "@vtex/tsconfig": "^0.4.4",
     "apollo-cache-inmemory": "^1.6.5",
     "graphql": "^14.6.0",
-    "typescript": "3.8.3",
+    "typescript": "3.9.7",
     "vtex.css-handles": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.2/public/@types/vtex.css-handles",
     "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.111.1/public/@types/vtex.render-runtime"
   }

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5282,12 +5282,7 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@3.8.3:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
-  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
-
-typescript@^3.9.7:
+typescript@3.9.7, typescript@^3.9.7:
   version "3.9.7"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
   integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==


### PR DESCRIPTION
#### What does this PR do? \*

This PR implements a filter prop in specifitations like in specificationGroup. The reason of this feature is give the posibility to filter and displays only the specification that you wants and be more specific when render the product specifications.

#### How to test it? \*

For test this feature, in store-theme, adds this prop in specification block:

"product-specification": {
    "children": [
      "product-specification-text#specification",
      "product-specification-values"
    ],
    "props": {
        "filter": {
                "specifications": ["<spacificationNamer>"],
                "type": "show"
        }
      }
  },

In the PDP you can see only the specification filtered.

#### Describe alternatives you've considered, if any. \*

<!--- Optional -->

#### Related to / Depends on \*

<!--- Optional -->
